### PR TITLE
Fix terminal blank screen on invalid color input

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -93,7 +93,10 @@ func FlagColor(ColorString string) termbox.Attribute {
 		if ColorString == "" {
 			return termbox.ColorGreen
 		} else {
-			num, _ := strconv.Atoi(ColorString)
+			num, err := strconv.Atoi(ColorString)
+			if err != nil || num > 256 || num < 1 {
+				return termbox.ColorGreen
+			}
 			return termbox.Attribute(num)
 		}
 	}


### PR DESCRIPTION
Passing an invalid color string or a number outside the 1–256 range causes the terminal to go blank. FlagColor should handle invalid input gracefully. Suggest adding a check for strconv.Atoi errors and out-of-range values, and fallback to a default